### PR TITLE
Add rule to require a title for every object type

### DIFF
--- a/docs/rules/object-title.md
+++ b/docs/rules/object-title.md
@@ -1,0 +1,39 @@
+# requires a title for any type that is an object
+
+Validates that a title exists for any defined type which is an `object`.
+
+## Examples of *correct* usage
+
+```json
+{
+  "type": "object",
+  "title": "Person",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "address": {
+      "type": "object",
+      "title": "Address",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}
+```
+
+## Examples of *incorrect* usage
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "address": {
+      "type": "object"
+    }
+  }
+}
+```


### PR DESCRIPTION
### Problem

There are schema `object` types which do not have a `title` property. This makes it difficult to discuss types, especially commonly re-used objects.

### Solution

Defined schema `object` types should have a `title` property. This property ensures there is a name for the object which can be referenced/presented.
