### PR TITLE
Add nested property support

### DIFF
--- a/docs/common.md
+++ b/docs/common.md
@@ -31,3 +31,18 @@ The `*Absent` option is as it sounds, will match only if the field is not presen
   "thenAbsent": true
 }
 ```
+
+## `nested properties`
+
+Properties within object types may be referenced in rules.  For example this is a custom response rule that ensures that all non-empty responses are of type object.
+
+```json
+"responses-custom": [
+       {
+        "whenField": "schema.type",
+        "whenPattern": "^((?!undefined).)*$",
+        "thenField": "schema.type",
+        "thenPattern": "^object$"
+        }
+]
+```

--- a/docs/common.md
+++ b/docs/common.md
@@ -34,7 +34,7 @@ The `*Absent` option is as it sounds, will match only if the field is not presen
 
 ## `nested properties`
 
-Properties within object types may be referenced in rules.  For example this is a custom response rule that ensures that all non-empty responses are of type object.
+Properties within object types may be referenced in rules using dot notation.  For example this is a custom response rule that ensures that all non-empty responses are of type object.
 
 ```json
 "responses-custom": [

--- a/lib/helpers/CustomValidator.js
+++ b/lib/helpers/CustomValidator.js
@@ -2,15 +2,17 @@
 
 const RuleFailure = require('../RuleFailure');
 const PatternOption = require('./PatternOption');
+
 /**
  * This function enables field names with dot notation to be
  * used, allowing the rules to look for nested field names.
  *
  * @param {Object} obj  The key's object
  * @param {String} path The option config for the field.
-*/
+ * @returns {String} The value of the field referenced in the path
+ */
 const getDescendantProp = (obj, path) => (
-    path.split('.').reduce((acc, part) => acc && acc[part], obj)
+  path.split('.').reduce((acc, part) => acc && acc[part], obj)
 );
 
 /**
@@ -30,7 +32,7 @@ function getFieldValue(fieldValueSpecifier, key, object) {
     return key;
   }
 
-  return getDescendantProp(object,fieldValueSpecifier);
+  return getDescendantProp(object, fieldValueSpecifier);
 }
 
 /**

--- a/lib/helpers/CustomValidator.js
+++ b/lib/helpers/CustomValidator.js
@@ -2,6 +2,16 @@
 
 const RuleFailure = require('../RuleFailure');
 const PatternOption = require('./PatternOption');
+/**
+ * This function enables field names with dot notation to be
+ * used, allowing the rules to look for nested field names.
+ *
+ * @param {Object} obj  The key's object
+ * @param {String} path The option config for the field.
+*/
+const getDescendantProp = (obj, path) => (
+    path.split('.').reduce((acc, part) => acc && acc[part], obj)
+);
 
 /**
  * Get the correct field, either the key or the object's field.
@@ -20,7 +30,7 @@ function getFieldValue(fieldValueSpecifier, key, object) {
     return key;
   }
 
-  return object[fieldValueSpecifier];
+  return getDescendantProp(object,fieldValueSpecifier);
 }
 
 /**

--- a/test/lib/rules/info-custom.js
+++ b/test/lib/rules/info-custom.js
@@ -101,19 +101,19 @@ describe('info-custom', () => {
   });
   describe('process nested properties in rules', () => {
     const options = {
-        "whenField": "license",
-        "whenPattern": ".*",
-        "thenField": "license.name",
-        "thenPattern": "^License Name$" 
+      whenField: 'license',
+      whenPattern: '.*',
+      thenField: 'license.name',
+      thenPattern: '^License Name$'
     };
 
     it('should not report errors when name property matches', () => {
       const schema = {
         info: {
-          license : {
-             name : 'License Name',
-              url : 'https://license.com'
-          } 
+          license: {
+            name: 'License Name',
+            url: 'https://license.com'
+          }
         }
       };
 
@@ -125,10 +125,10 @@ describe('info-custom', () => {
     it('should report errors when name property does not match', () => {
       const schema = {
         info: {
-          license : {
-             name : 'none',
-              url : 'https://license.com'
-          } 
+          license: {
+            name: 'none',
+            url: 'https://license.com'
+          }
         }
       };
 

--- a/test/lib/rules/info-custom.js
+++ b/test/lib/rules/info-custom.js
@@ -99,4 +99,44 @@ describe('info-custom', () => {
       assert.equal(failures.size, 0);
     });
   });
+  describe('process nested properties in rules', () => {
+    const options = {
+        "whenField": "license",
+        "whenPattern": ".*",
+        "thenField": "license.name",
+        "thenPattern": "^License Name$" 
+    };
+
+    it('should not report errors when name property matches', () => {
+      const schema = {
+        info: {
+          license : {
+             name : 'License Name',
+              url : 'https://license.com'
+          } 
+        }
+      };
+
+      const failures = infoCustomRule.validate(options, schema);
+
+      assert.equal(failures.size, 0);
+    });
+
+    it('should report errors when name property does not match', () => {
+      const schema = {
+        info: {
+          license : {
+             name : 'none',
+              url : 'https://license.com'
+          } 
+        }
+      };
+
+      const failures = infoCustomRule.validate([options], schema);
+
+      assert.equal(failures.size, 1);
+      assert.equal(failures.get(0).get('location'), 'info');
+      assert.equal(failures.get(0).get('hint'), 'Expected info license.name:"none" to match "^License Name$"');
+    });
+  });
 });


### PR DESCRIPTION
### Problem

Provide ability to evaluate nested properties within rules. For example:
(rule - License object must contain a specific name value)

"info-custom": [
       {
        "whenField": "license",
        "whenPattern": ".*",
        "thenField": "license.name",
        "thenPattern": "^License: Creative Commons Attribution 4.0 International Public License$" 
        }
]

### Solution

Updated CustomValidator.js to traverse the schema object when thenFields or whenFields have names with dot notation.
Added explanation of how to provide nested property names in rules in common.md
Updated info-custom.js in the test rules directory to add a few tests that contain nested properties.  Not sure if this is enough.
