### PR TITLE
enhance dereferencing of parameters

### DIFF
--- a/lib/helpers/SchemaObjectParser.js
+++ b/lib/helpers/SchemaObjectParser.js
@@ -17,7 +17,7 @@ class SchemaObjectParser {
    * @param {Function} schemaFunction The function that checks schema objects. Can be undefined.
    * @param {Function} propertyFunction The function that checks properties. Can be undefined.
    * @param {Function} refFunction The function that checks schemas pointing to a $ref.
-  *                               Can be undefined.
+   *                               Can be undefined.
    * @param {Object} schemaObject The schema object being checked.
    * @param {Object} pathToSchema The path to the schema used for error messages.
    */
@@ -32,17 +32,13 @@ class SchemaObjectParser {
         return;
       }
       this.visitedRefs.push(schemaObject.$ref);
-
       if (refFunction) {
         refFunction(schemaObject, pathToSchema);
       }
 
-      if (schemaObject.$ref.startsWith('#/definitions/')) {
-        const trimmedRef = schemaObject.$ref.substr(2);
-        const splitRef = trimmedRef.split('/');
+      const referencedSchema = this.followRef(schemaObject.$ref);
 
-        const referencedSchema = this.rootSchema.definitions[splitRef[1]];
-
+      if (referencedSchema !== undefined) {
         this.checkSchemaObject(
           schemaFunction, propertyFunction, refFunction, referencedSchema, pathToSchema);
       } else {
@@ -56,12 +52,27 @@ class SchemaObjectParser {
       if (schemaFunction) {
         schemaFunction(schemaObject, pathToSchema);
       }
-
       if (schemaObject.type === 'object' || schemaObject.openapilintType === 'allOf') {
         if (schemaObject.properties) {
           Object.keys(schemaObject.properties).forEach((propertyKey) => {
-            const propertyObject = schemaObject.properties[propertyKey];
+            let propertyObject = schemaObject.properties[propertyKey];
             const pathToProperty = `${pathToSchema}.properties.${propertyKey}`;
+
+            /* derefence any properties that are just references. */
+            if (propertyObject.$ref !== undefined) {
+              if (_.includes(this.visitedRefs, propertyObject.$ref)) {
+                // found a ref that's already been visited. Skip it.
+                return;
+              }
+              this.visitedRefs.push(propertyObject.$ref);
+              propertyObject = this.followRef(propertyObject.$ref);
+              if (propertyObject === undefined) {
+                this.errorList.push(new RuleFailure({
+                  location: `${pathToSchema}`,
+                  hint: 'Found a non-internal reference'
+                }));
+              }
+            }
 
             if (propertyFunction) {
               propertyFunction(propertyKey, propertyObject, pathToProperty);
@@ -73,6 +84,13 @@ class SchemaObjectParser {
         }
       } else if (schemaObject.type === 'array' && schemaObject.items) {
         this.checkSchemaObject(schemaFunction, propertyFunction, refFunction, schemaObject.items, `${pathToSchema}.items`);
+      } else if (schemaObject.in !== undefined) {
+        // schemaobject is a simple parameter - header parameters are common example
+        if (propertyFunction) {
+          const pathToParameter = `${pathToSchema}`;
+
+          propertyFunction(schemaObject.name, schemaObject, pathToParameter);
+        }
       }
     }
 
@@ -108,7 +126,16 @@ class SchemaObjectParser {
 
           if (operation.parameters) {
             operation.parameters.forEach((parameter, parameterIndex) => {
-              this.checkSchemaObject(schemaFunction, propertyFunction, refFunction, parameter.schema, `paths.${pathKey}.${operationKey}.parameters[${parameterIndex}].schema`);
+              let paramToPass = parameter;
+              let pathToPass = `paths.${pathKey}.${operationKey}.parameters[${parameterIndex}]`;
+
+              // parameters can have schemas and within schemas $ref properties
+              if (parameter.schema !== undefined) {
+                paramToPass = parameter.schema;
+                pathToPass = `paths.${pathKey}.${operationKey}.parameters[${parameterIndex}].schema`;
+              }
+              this.checkSchemaObject(schemaFunction, propertyFunction, refFunction, paramToPass,
+                pathToPass);
             });
           }
 
@@ -146,6 +173,25 @@ class SchemaObjectParser {
 
     return this.visitedRefs;
   }
-}
 
+  /**
+   * Attempts to follow a reference and return the associated properties.
+   * If the reference is external, undefined will be returned so the
+   * calling function can perform error handling.
+   *
+   * @param {function} pathToReference the path to the reference
+   * @returns {map} the map of properties defined for the reference or
+   * undefined if the reference is external
+   */
+  followRef(pathToReference) {
+    if (pathToReference.startsWith('#/')) {
+      const trimmedRef = pathToReference.substr(2);
+      const splitRef = trimmedRef.split('/');
+
+      return (this.rootSchema[splitRef[0]][splitRef[1]]);
+    }
+
+    return (undefined);
+  }
+}
 module.exports = SchemaObjectParser;

--- a/lib/helpers/TextParser.js
+++ b/lib/helpers/TextParser.js
@@ -62,7 +62,6 @@ class TextParser {
         // no path descriptions or titles
         Object.keys(_.pick(path, constants.httpMethods)).forEach((operationKey) => {
           const operation = path[operationKey];
-          const parameters = operation.parameters;
           const responses = operation.responses;
 
           if (applyToDescription && operation.description) {
@@ -71,14 +70,6 @@ class TextParser {
 
           if (applyToSummary && operation.summary) {
             textContentFunction(operation.summary, `paths.${pathKey}.${operationKey}.summary`);
-          }
-
-          if (parameters) {
-            parameters.forEach((parameter, parameterIndex) => {
-              if (applyToDescription && parameter.description) {
-                textContentFunction(parameter.description, `paths.${pathKey}.${operationKey}.parameters[${parameterIndex}].description`);
-              }
-            });
           }
 
           if (responses) {

--- a/lib/rules/parameters-custom.js
+++ b/lib/rules/parameters-custom.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const _ = require('lodash');
-
 const List = require('immutable').List;
 
-const constants = require('../constants');
 const CustomValidator = require('../helpers/CustomValidator');
+const SchemaObjectParser = require('../helpers/SchemaObjectParser');
 
 const rule = {
   description: 'enforce parameters comply with custom config constraints',
@@ -13,31 +11,12 @@ const rule = {
     const errorList = [];
 
     const myCustomValidator = new CustomValidator(options, schema, errorList);
+    const mySchemaObjectParser = new SchemaObjectParser(schema, errorList);
 
     myCustomValidator.validateOptions();
-
-    if (schema.paths) {
-      Object.keys(schema.paths).forEach((pathKey) => {
-        const path = schema.paths[pathKey];
-
-        // check each operation
-        Object.keys(_.pick(path, constants.httpMethods)).forEach((operationKey) => {
-          const operation = path[operationKey];
-
-          if (operation.parameters) {
-            operation.parameters.forEach((parameter, parameterIndex) => {
-              myCustomValidator.validateAllCustoms(
-                undefined, // parameters have no key name coming from a list.
-                parameter,
-                `paths.${pathKey}.${operationKey}.parameters[${parameterIndex}]`,
-                'parameter',
-                () => true
-              );
-            });
-          }
-        });
-      });
-    }
+    mySchemaObjectParser.forEachProperty((propertyKey, propertyObject, pathToProperty) => {
+      myCustomValidator.validateAllCustoms(propertyKey, propertyObject, pathToProperty, 'parameter', () => true);
+    });
 
     return new List(errorList);
   }

--- a/test/lib/rules/no-restricted-words.js
+++ b/test/lib/rules/no-restricted-words.js
@@ -107,14 +107,22 @@ describe('no-restricted-words', () => {
     assert.equal(failures.get(1).get('hint'), 'Found \'restricted blah-blah\'');
     assert.equal(failures.get(2).get('location'), 'info.description');
     assert.equal(failures.get(2).get('hint'), 'Found \'restricted\'');
-    assert.equal(failures.get(3).get('location'), 'paths./pets.get.description');
+    assert.equal(failures.get(3).get('location'), 'paths./pets.get.parameters[0].description');
     assert.equal(failures.get(3).get('hint'), 'Found \'restricted\'');
-    assert.equal(failures.get(4).get('location'), 'paths./pets.get.summary');
+    assert.equal(failures.get(4).get('location'), 'paths./people.get.parameters[0].description');
     assert.equal(failures.get(4).get('hint'), 'Found \'restricted\'');
-    assert.equal(failures.get(5).get('location'), 'paths./pets.get.parameters[0].description');
-    assert.equal(failures.get(5).get('hint'), 'Found \'restricted\'');
-    assert.equal(failures.get(6).get('location'), 'paths./pets.get.responses.200.description');
+    assert.equal(failures.get(6).get('location'), 'paths./pets.get.summary');
     assert.equal(failures.get(6).get('hint'), 'Found \'restricted\'');
+    assert.equal(failures.get(5).get('location'), 'paths./pets.get.description');
+    assert.equal(failures.get(5).get('hint'), 'Found \'restricted\'');
+    assert.equal(failures.get(7).get('location'), 'paths./pets.get.responses.200.description');
+    assert.equal(failures.get(7).get('hint'), 'Found \'restricted\'');
+    assert.equal(failures.get(8).get('location'), 'paths./people.get.description');
+    assert.equal(failures.get(8).get('hint'), 'Found \'restricted\'');
+    assert.equal(failures.get(9).get('location'), 'paths./people.get.summary');
+    assert.equal(failures.get(9).get('hint'), 'Found \'restricted\'');
+    assert.equal(failures.get(10).get('location'), 'paths./people.get.responses.200.description');
+    assert.equal(failures.get(10).get('hint'), 'Found \'restricted\'');
   });
 
   it('should report error when info.title has restricted words', () => {
@@ -398,10 +406,10 @@ describe('no-restricted-words', () => {
 
     assert.equal(failures.size, 3);
 
-    assert.equal(failures.get(0).get('location'), 'paths./pets.get.description');
-    assert.equal(failures.get(0).get('hint'), 'Found \'Sample operation description of MY DEPRECATED brand\'');
-    assert.equal(failures.get(1).get('location'), 'paths./pets.get.parameters[0].description');
-    assert.equal(failures.get(1).get('hint'), 'Found \'Sample param description for my DEPRECATED brand\'');
+    assert.equal(failures.get(1).get('location'), 'paths./pets.get.description');
+    assert.equal(failures.get(1).get('hint'), 'Found \'Sample operation description of MY DEPRECATED brand\'');
+    assert.equal(failures.get(0).get('location'), 'paths./pets.get.parameters[0].description');
+    assert.equal(failures.get(0).get('hint'), 'Found \'Sample param description for my DEPRECATED brand\'');
     assert.equal(failures.get(2).get('location'), 'paths./pets.get.responses.200.description');
     assert.equal(failures.get(2).get('hint'), 'Found \'sample response for my deprecated brand\'');
   });

--- a/test/lib/rules/text-content.js
+++ b/test/lib/rules/text-content.js
@@ -62,10 +62,10 @@ describe('text-content', () => {
       assert.equal(failures.size, 3);
       assert.equal(failures.get(0).get('location'), 'info.title');
       assert.equal(failures.get(0).get('hint'), 'Expected "    Title with spaces" to match "^[A-Z]"');
-      assert.equal(failures.get(1).get('location'), 'paths./pets.get.summary');
-      assert.equal(failures.get(1).get('hint'), 'Expected "the lower case summary" to match "^[A-Z]"');
-      assert.equal(failures.get(2).get('location'), 'paths./pets.get.parameters[0].description');
-      assert.equal(failures.get(2).get('hint'), 'Expected "the lower case description" to match "^[A-Z]"');
+      assert.equal(failures.get(1).get('location'), 'paths./pets.get.parameters[0].description');
+      assert.equal(failures.get(1).get('hint'), 'Expected "the lower case description" to match "^[A-Z]"');
+      assert.equal(failures.get(2).get('location'), 'paths./pets.get.summary');
+      assert.equal(failures.get(2).get('hint'), 'Expected "the lower case summary" to match "^[A-Z]"');
     });
   });
 
@@ -200,10 +200,10 @@ describe('text-content', () => {
       const failures = textContentRule.validate(options, schema);
 
       assert.equal(failures.size, 2);
-      assert.equal(failures.get(0).get('location'), 'paths./pets.get.summary');
-      assert.equal(failures.get(0).get('hint'), 'Expected "The incorrect summary without punctuation" to match "\\.$"');
-      assert.equal(failures.get(1).get('location'), 'paths./pets.get.parameters[0].description');
-      assert.equal(failures.get(1).get('hint'), 'Expected "The incorrect description with trailing spaces.   " to match "\\.$"');
+      assert.equal(failures.get(0).get('location'), 'paths./pets.get.parameters[0].description');
+      assert.equal(failures.get(0).get('hint'), 'Expected "The incorrect description with trailing spaces.   " to match "\\.$"');
+      assert.equal(failures.get(1).get('location'), 'paths./pets.get.summary');
+      assert.equal(failures.get(1).get('hint'), 'Expected "The incorrect summary without punctuation" to match "\\.$"');
     });
   });
 


### PR DESCRIPTION
Hello,
We have been using the linter tool for a while now and actually encountered some of the $ref following gaps similar to another [open issue](https://github.com/paypal/openapilint/issues/40). Parameters seem to be defined in one of 2 forms:

inline simple property:

'/wild-animals':
post:
parameters:

name: 'PayPal-Request-Id',
in: 'header',
type: 'string',
description: 'The server stores keys forever.',
required: false
Or as a reference:
'/pets':
post:
parameters:

$ref: '#/definitions/headerRef'
definitions:
headerRef:
name: 'PayPal-Request-Id',
in: 'header',
description: 'The server stores keys for 24 hours',
required: false,
type: 'string'

I added logic to SchemaObjectParser.js to differentiate these two use cases. In particular the simple form is detected by looking for the "in" property which is required for the parameter object.
Additionally, we use custom definition paths for some of our referenceable objects so that they get categorized. This resulted in changes to SchemaObjectParser.js to follow references using a more generic pattern.
These changes allowed the parameter-custom.js to look almost identical to properties-custom.js as there was no longer need to have special logic to look for parameters in the rules themselves. Similarly, TextParser.js no longer needs to do parameter checks as that is solely accomplished in SchemaObjectParser.js.
I updated the test suite to cover the multiple parameter forms and they run successfully, however, all these changes should have a review by others before committing.